### PR TITLE
Fix failing GitHub Actions workflows (tokens, permissions, auto-fix logic)

### DIFF
--- a/.github/workflows/ai-issue-handler.yml
+++ b/.github/workflows/ai-issue-handler.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Post Comment
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.gh_token }}
+          github-token: ${{ github.token }}
           script: |
             const response = process.env.RESPONSE;
             if (response) {

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Post PR Comment
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.gh_token }}
+          github-token: ${{ github.token }}
           script: |
             const review = process.env.REVIEW_RESULT;
             if (review) {

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main, master, develop ]
 
+permissions:
+  contents: write
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -30,16 +33,17 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          git diff --exit-code
-          if [ $? -ne 0 ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
-          
+
       - name: Commit and push changes
         if: steps.changes.outputs.has_changes == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add .
-          git commit -m "Auto-fix: Format code [skip ci]" -m "Auto-generated commit by GitHub Actions" || echo "No changes to commit"
+          git commit -m "Auto-fix: Format code [skip ci]" -m "Auto-generated commit by GitHub Actions"
           git push

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v1
         with:
-          github-token: "${{ secrets.gh_token }}"
+          github-token: "${{ github.token }}"
 
       - name: Approve and Merge Security Updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
@@ -23,4 +23,4 @@ jobs:
           gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.gh_token}}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/report-build-failure.yml
+++ b/.github/workflows/report-build-failure.yml
@@ -19,14 +19,13 @@ jobs:
       - name: Report Failure
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.gh_token }}
+          github-token: ${{ github.token }}
           script: |
             const runId = context.payload.workflow_run.id;
             const runUrl = context.payload.workflow_run.html_url;
             const repoOwner = context.repo.owner;
             const repoName = context.repo.repo;
 
-            // 1. Find the failed job
             const jobs = await github.rest.actions.listJobsForWorkflowRun({
               owner: repoOwner,
               repo: repoName,
@@ -34,36 +33,15 @@ jobs:
               filter: 'latest'
             });
 
-            const failedJob = jobs.data.jobs.find(job => job.conclusion === 'failure');
-            
-            let logSnippet = "Could not retrieve logs.";
-            
-            if (failedJob) {
-              try {
-                // 2. Retrieve logs for the failed job
-                const logs = await github.rest.actions.downloadJobLogsForWorkflowRun({
-                  owner: repoOwner,
-                  repo: repoName,
-                  job_id: failedJob.id,
-                  run_id: runId
-                });
+            const failedJobs = jobs.data.jobs.filter(job => job.conclusion === 'failure');
+            const failedSummary = failedJobs.length
+              ? failedJobs.map(job => `- ${job.name}`).join('\n')
+              : '- Unknown failed job';
 
-                // 3. Extract the last 50 lines or relevant error section
-                const logContent = String(logs.data);
-                const lines = logContent.split('\n');
-                const lastLines = lines.slice(-50).join('\n');
-                logSnippet = "```\n" + lastLines + "\n```";
-              } catch (e) {
-                console.log("Error fetching logs: " + e.message);
-                logSnippet = "Logs could not be fetched automatically. Please check the Action run.";
-              }
-            }
-
-            // 4. Create the Issue
             await github.rest.issues.create({
               owner: repoOwner,
               repo: repoName,
               title: `🚨 Build Failed: ${context.payload.workflow_run.name}`,
-              body: `The build failed in the **${failedJob ? failedJob.name : 'unknown'}** job.\n\n[View Run](${runUrl})\n\n### Error Log Snippet\n${logSnippet}\n\n@${context.payload.workflow_run.actor.login} please investigate.`,
+              body: `The workflow run failed.\n\n[View Run](${runUrl})\n\n### Failed Jobs\n${failedSummary}\n\n@${context.payload.workflow_run.actor.login} please investigate.`,
               labels: ['needs-ai', 'build-failure']
             });


### PR DESCRIPTION
### Motivation
- Prevent recurring automation failures caused by missing custom secrets, insufficient workflow permissions, and brittle shell/API handling in CI workflows.
- Make auto-format push-backs and automation merges reliable in standard repository setups by using built-in tokens and explicit permissions.

### Description
- Replaced `secrets.gh_token` with the built-in `${{ github.token }}` in `ai-issue-handler.yml`, `ai-pr-reviewer.yml`, `dependabot-auto-merge.yml`, and `report-build-failure.yml` to avoid failures when a custom secret is not present.
- Updated `auto-fix.yml` to add `permissions: contents: write` and changed change detection to use `git diff --quiet` with a deterministic `$GITHUB_OUTPUT` value to avoid failures under `set -e` and ensure push-back can run.
- Simplified `report-build-failure.yml` by removing fragile job-log download and extraction logic and instead listing failed job names from the workflow run summary to produce a reliable issue body.
- Ensured `dependabot-auto-merge.yml` uses `${{ github.token }}` consistently for metadata and `gh` CLI operations by setting `GITHUB_TOKEN: ${{ github.token }}`.

### Testing
- YAML validation using Ruby (`require 'yaml'; YAML.load_file(...)`) was run against each workflow and reported `OK` for all modified files.
- `npx -y actionlint` was attempted but failed due to an `npm` runtime error unrelated to the workflow YAML changes (reported as an error from the local npm environment).
- Syntactic checks and local diffs were inspected to confirm the updated workflows are well-formed and the intended token/permission and logic changes are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ce1a35937c832891b516e9256c1f88)